### PR TITLE
Fixed error if second parameter in Attrio::Types::Integer.typecast - nil...

### DIFF
--- a/lib/attrio/types/integer.rb
+++ b/lib/attrio/types/integer.rb
@@ -4,10 +4,10 @@ module Attrio
   module Types
     class Integer < Base
       def self.typecast(value, options = {})
-        options[:base] ||= 10
+        base = options.is_a?(Hash) && options[:base] ? options[:base] : 10
         
         begin
-          return value.to_i(options[:base]) if value.is_a?(String)
+          return value.to_i(base) if value.is_a?(String)
           return value.to_i
         rescue NoMethodError => e
           nil


### PR DESCRIPTION
Fixed this case:

``` ruby
class MyUser
  include Attrio

  define_attributes :as => :settings do
    attr :skill_ids, Array, :split=>',', :element => { :type => Integer }
  end

  def initialize()

  end

end
```

```
2.0.0p247 :002 > u = MyUser.new
 => #<MyUser skill_ids: nil> 
2.0.0p247 :003 > u.skill_ids = '1,2,3'
NoMethodError: undefined method `[]' for nil:NilClass
        from .../www/attrio/vendor/gems/attrio/lib/attrio/types/integer.rb:7:in `typecast'
        from .../www/attrio/vendor/gems/attrio/lib/attrio/types/array.rb:16:in `block in typecast'
        from .../www/attrio/vendor/gems/attrio/lib/attrio/types/array.rb:14:in `map!'
        from .../www/attrio/vendor/gems/attrio/lib/attrio/types/array.rb:14:in `typecast'
        from .../www/attrio/vendor/gems/attrio/lib/attrio/builders/writer_builder.rb:28:in `block in define_typecasting_method'
        from (irb):3
        from .../.rvm/rubies/ruby-2.0.0-p247/bin/irb:16:in `<main>'

```

and second variant not implemented: 

``` ruby
module Attrio
  module Types
    class Array < Base

  #...
      def self.element_options(element)
        element[:options] || {} # this line
      rescue
        {}
      end
    end
  end
end
```

sorry, without tests 
