### PR TITLE
Fix reset process when initialize with boolean parameter

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,2 @@
---format nested
+--format d
 --color

--- a/attrio.gemspec
+++ b/attrio.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_development_dependency 'rspec'
+  gem.add_development_dependency 'rspec-its'
   gem.add_development_dependency 'webmock', '~> 1.9.0'
   gem.add_development_dependency 'simplecov'
   gem.add_development_dependency 'json'

--- a/lib/attrio/initialize.rb
+++ b/lib/attrio/initialize.rb
@@ -22,7 +22,7 @@ module Attrio
     private
 
     def blank_attribute?(obj, attribute_name, attribute)
-      if attribute.type <= Attrio::Types::Boolean
+      if attribute.type && attribute.type <= Attrio::Types::Boolean
         obj.send(attribute_name).nil?
       else
         obj.send(attribute_name).blank?

--- a/lib/attrio/initialize.rb
+++ b/lib/attrio/initialize.rb
@@ -12,11 +12,21 @@ module Attrio
         obj.class.send("#{group}").each do |name, attribute|
           obj.send("#{group}")[name] = attribute.dup
           obj.send("#{group}")[name].instance_variable_set(:@object, obj)
-          obj.send("#{group}")[name].reset! if obj.send(name).blank?
+          obj.send("#{group}")[name].reset! if blank_attribute?(obj, name, attribute)
         end
       end
 
       obj
+    end
+
+    private
+
+    def blank_attribute?(obj, attribute_name, attribute)
+      if attribute.type <= Attrio::Types::Boolean
+        obj.send(attribute_name).nil?
+      else
+        obj.send(attribute_name).blank?
+      end
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,7 @@ $:.unshift File.expand_path('../../lib', __FILE__)
 
 require 'attrio'
 require 'rspec'
+require 'rspec/its'
 require 'webmock/rspec'
 require 'json'
 require 'coveralls'
@@ -19,7 +20,6 @@ end
 RSpec.configure do |config|
   config.include WebMock::API
   config.order = :rand
-  config.color_enabled = true
   config.treat_symbols_as_metadata_keys_with_true_values = true
 
   config.before(:each) do

--- a/spec/unit/attrio_spec.rb
+++ b/spec/unit/attrio_spec.rb
@@ -73,4 +73,45 @@ describe Attrio do
       its(:api_attributes){ should be_present }
     end
   end
+
+  describe 'includeing MassAssignment' do
+    module MassAssignment
+      def initialize(attributes = {})
+        self.attributes = attributes
+      end
+
+      def attributes=(attributes = {})
+        attributes.each do |attr,value|
+          self.send("#{attr}=", value) if self.respond_to?("#{attr}=")
+        end
+      end
+    end
+
+    let(:model) do
+      Class.new do
+        include Attrio
+        include MassAssignment
+
+        define_attributes do
+          attr :name, String
+          attr :age, Integer
+          attr :activated, Boolean
+        end
+      end
+    end
+
+    context "initialize with attributes" do
+      subject do
+        model.new(
+          name: "name",
+          age: 0,
+          activated: false,
+        )
+      end
+
+      it { expect(subject.name).to eq "name" }
+      it { expect(subject.age).to eq 0 }
+      it { expect(subject.activated).to eq false }
+    end
+  end
 end


### PR DESCRIPTION
if initialize is given `false` parameter,
Boolean attribute is resetted.

for example, definition like README

``` ruby
module MassAssignment
  def initialize(attributes = {})
    self.attributes = attributes
  end

  def attributes=(attributes = {})
    attributes.each do |attr,value|
      self.send("#{attr}=", value) if self.respond_to?("#{attr}=")
    end
  end
end

class City
  include Attrio
  include MassAssignment

  define_attributes do
    attr :name, String
    attr :capital, Boolean
  end
end
```

Object initialization

``` ruby
city = City.new(name: "Osaka", capital: false)
city.capital # => this should be `false`, but this is `nil`
```

Reason

``` ruby
obj.send("#{group}")[name].reset! if obj.send(name).blank?
```

`false.blank?` is `true`, and attribute is resetted.
